### PR TITLE
Update coverage and ignore test files for build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": ["@babel/env", "@babel/preset-typescript"]
+  "presets": ["@babel/env", "@babel/preset-typescript"],
+  "ignore": [
+    "node_modules",
+    "test",
+    "**/__mocks__",
+    "**/__tests__"
+  ]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   collectCoverageFrom: ["**/src/**", "!**/src/__*__/**"],
   coverageThreshold: {
     global: {
-      branches: 30,
-      functions: 40,
-      lines: 40,
-      statements: 35,
+      branches: 65,
+      functions: 90,
+      lines: 80,
+      statements: 80,
     },
   },
   testPathIgnorePatterns: [


### PR DESCRIPTION
Updating coverage thresholds to be closer to actual coverage. Additionally, corrected an issue with `__mocks__` and `__tests__` directories being compiled as part of a standard build